### PR TITLE
Fix streaming for cameras with stale Wyze cloud API IP

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -420,15 +420,25 @@ export class WyzeNativeCamera
   }
 
   private async createRfcServer(): Promise<WyzeRfc4571Server> {
+    // Refresh IPs from Wyze cloud — the API can return stale IPs after DHCP renewals.
+    // Debounced to at most once per 5 minutes so retries don't spam the API.
+    await this.provider.refreshCameraIps().catch(() => {});
+
     const info = this.provider.getCameraInfo(this.nativeId);
     if (!info?.ip || !info?.p2pId || !info?.enr || !info?.mac)
       throw new Error(`Incomplete camera info for ${this.nativeId}. Run discovery.`);
 
+    const ipBefore = info.ip;
     this.console.log(`Connecting to ${info.nickname} (${info.ip})...`);
     const { createWyzeRfc4571Server } = await import("@apocaliss92/wyze-bridge-js");
     const server = await createWyzeRfc4571Server({
       camera: info, frameSize: this.getResolutionFrameSize(), bitrate: this.getBitrateValue(), logger: this.console,
     });
+    // Persist updated IP if broadcast discovery found the camera at a different address
+    if (info.ip !== ipBefore) {
+      this.console.log(`Persisting updated IP for ${info.nickname}: ${ipBefore} → ${info.ip}`);
+      this.provider.updateCameraIp(this.nativeId, info.ip);
+    }
     this.console.log(`✅ P2P: tcp://${server.host}:${server.port} (${server.videoType})`);
 
     // Start idle timer when last TCP client disconnects

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ export default class WyzeNativeProvider
   implements DeviceProvider, DeviceCreator, DeviceDiscovery, Settings
 {
   private cameras = new Map<string, WyzeNativeCamera>();
+  private lastIpRefreshAt = 0;
 
   constructor(nativeId?: string) {
     super(nativeId);
@@ -306,11 +307,53 @@ export default class WyzeNativeProvider
     }
   }
 
+  /** Update the stored IP for a camera (e.g. after broadcast discovery found it at a different address) */
+  updateCameraIp(nativeId: string, ip: string): void {
+    const raw = this.getCameraInfo(nativeId);
+    if (raw) this.storage.setItem(`cam:${nativeId}`, JSON.stringify({ ...raw, ip }));
+  }
+
   /** Get stored camera info for a given nativeId */
   getCameraInfo(nativeId: string): any {
     try {
       const raw = this.storage.getItem(`cam:${nativeId}`);
       return raw ? JSON.parse(raw) : null;
     } catch { return null; }
+  }
+
+  /**
+   * Refresh camera IPs from the Wyze cloud API.
+   * Debounced to at most once per 5 minutes — Wyze API returns the last-known
+   * local IP for each camera, which can become stale if DHCP reassigns the address.
+   */
+  async refreshCameraIps(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastIpRefreshAt < 5 * 60 * 1000) return;
+    if (!this.hasCredentials()) return;
+
+    try {
+      const { WyzeCloud } = await import("@apocaliss92/wyze-bridge-js");
+      const creds = this.getCloudCredentials();
+      const cloud = new WyzeCloud({
+        apiKey: creds.apiKey,
+        apiId: creds.apiId,
+        loadSession: () => { try { const r = this.storage.getItem("wyze-session"); return r ? JSON.parse(r) : null; } catch { return null; } },
+        saveSession: (s) => { this.storage.setItem("wyze-session", JSON.stringify(s)); },
+        clearSession: () => { this.storage.removeItem("wyze-session"); },
+      });
+      await cloud.ensureSession(creds.email, creds.password);
+      const cameras = await cloud.getCameraList();
+      for (const cam of cameras) {
+        const id = cam.mac.toUpperCase();
+        const prev = this.getCameraInfo(id);
+        if (prev && prev.ip !== cam.ip) {
+          this.console.log(`IP updated for ${cam.nickname}: ${prev.ip} → ${cam.ip}`);
+        }
+        this.storage.setItem(`cam:${id}`, JSON.stringify(cam));
+      }
+      this.lastIpRefreshAt = now;
+    } catch (e: any) {
+      this.console.warn(`Camera IP refresh failed: ${e?.message}`);
+    }
   }
 }

--- a/wyze-bridge
+++ b/wyze-bridge
@@ -1,1 +1,1 @@
-/Users/gianlucaruocco/Documents/Git/wyze-bridge-js
+../wyze-bridge-js


### PR DESCRIPTION
## Problem

The Wyze cloud API returns the camera's last-known local IP, which becomes stale after DHCP reassignment. Connections timeout immediately because the stored IP belongs to a different device on the network.

## Fix

- Call `refreshCameraIps()` before each connection attempt (debounced to 5 minutes) to fetch a fresher IP from the Wyze cloud API
- After `createWyzeRfc4571Server()` returns, check whether the underlying P2P library updated `camera.ip` via broadcast/subnet discovery (see companion PR to wyze-bridge-js)
- If the IP changed, call `updateCameraIp()` to persist the corrected address so future connections use it directly without re-scanning
- Added `updateCameraIp()` helper to `WyzeNativeProvider`

## Tested on

- Wyze Bulb Cam (HL_BC) — camera had moved from 10.0.1.123 to 10.0.1.156 after DHCP reassignment. Stream now connects and plays successfully in Scrypted and HomeKit.